### PR TITLE
fix: hiding sprite panel after selecting sprite

### DIFF
--- a/src/containers/sprite-library.jsx
+++ b/src/containers/sprite-library.jsx
@@ -9,6 +9,8 @@ import randomizeSpritePosition from '../lib/randomize-sprite-position'
 import spriteTags from '../lib/libraries/sprite-tags'
 
 import LibraryComponent from '../components/library/library.jsx'
+import { setSpriteClickedState } from '../reducers/vm-status.js'
+import { connect } from 'react-redux'
 
 const messages = defineMessages({
   libraryTitle: {
@@ -29,6 +31,7 @@ class SpriteLibrary extends React.PureComponent {
     this.props.vm.addSprite(JSON.stringify(item)).then(() => {
       this.props.onActivateBlocksTab()
     })
+    this.props.setSpriteClickedState(false);
   }
   render() {
     return (
@@ -51,4 +54,8 @@ SpriteLibrary.propTypes = {
   vm: PropTypes.instanceOf(VM).isRequired,
 }
 
-export default injectIntl(SpriteLibrary)
+const mapDispatchToProps = {
+  setSpriteClickedState,
+}
+
+export default injectIntl(connect(null,mapDispatchToProps)(SpriteLibrary))


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
